### PR TITLE
exclude maven-archetype from artifactId-name match

### DIFF
--- a/src/main/resources/exceptions-for-tests.yaml
+++ b/src/main/resources/exceptions-for-tests.yaml
@@ -123,6 +123,7 @@ givenAllArticles_whenAnArticleLoads_thenItDoesNotLinkToOldJavaDocs:
 givenTutorialsRepo_whenAllModulesAnalysed_thenFolderNameAndArtifiactIdAndModuleNameMatch:
  - /spring-cloud/spring-cloud-zuul-eureka-integration/bin
  - /guest/slf4j/guide
+ - /maven-archetype
 givenAGitHubModuleReadme_whenAnalysingTheReadme_thenLinksToAndFromGithubMatch:
  - https://github.com/eugenp/tutorials/blob/master/README.md
  


### PR DESCRIPTION
in this module, groupId, artifactId and version are parameterized and cannot be same as the module name.