### PR TITLE
Updated ignore-list-for-empty-missing-readme-test.yaml

### DIFF
--- a/src/main/resources/ignore-list-for-empty-missing-readme-test.yaml
+++ b/src/main/resources/ignore-list-for-empty-missing-readme-test.yaml
@@ -71,6 +71,7 @@ ignoreReadmeContaining:
   - /version-collision/
   - /versions-maven-plugin/
   - /maven-archetype/
+  - /maven-classifier  
   
 # parent modules that just group other modules but don't have any article themselves
 # we want to ignore the module itself here

--- a/src/main/resources/ignore-list-for-empty-missing-readme-test.yaml
+++ b/src/main/resources/ignore-list-for-empty-missing-readme-test.yaml
@@ -71,7 +71,7 @@ ignoreReadmeContaining:
   - /version-collision/
   - /versions-maven-plugin/
   - /maven-archetype/
-  - /maven-classifier  
+  - /maven-classifier/
   
 # parent modules that just group other modules but don't have any article themselves
 # we want to ignore the module itself here


### PR DESCRIPTION
added /maven-classifier (https://github.com/eugenp/tutorials/tree/master/maven-modules/maven-classifier)
Related Jira: https://team.baeldung.com/browse/BAEL-49952